### PR TITLE
Update GitHub Actions to fix artifact deprecation warnings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
       - name: Install, build, and upload your site output
-        uses: withastro/action@v1
+        uses: withastro/action@v5
         with:
           path: . # The root location of your Astro project inside the repository. (optional)
           node-version: 20 # The specific version of Node that should be used to build your site. (optional)
@@ -36,4 +36,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
- Upgrade withastro/action from v1 to v5 (includes artifact v4 support)
- Upgrade actions/deploy-pages from v3 to v4
- Resolves deprecation warning for actions/upload-artifact@v3

Fixes deployment failures due to deprecated artifact actions.